### PR TITLE
Make the GitHub button actually go to GitHub

### DIFF
--- a/settings/index.html
+++ b/settings/index.html
@@ -83,7 +83,11 @@
             </div>
             <div class="bottombar">
                 <a class="alt-btn" href="/">Back</a>
+<<<<<<< Updated upstream
                 <a class="alt-btn" href="#" target="_blank">GitHub</a>
+=======
+                <a class="alt-btn" href="https://github.com/Ascript89/onliine/" target="_blank">GitHub</a>
+>>>>>>> Stashed changes
             </div>
         </div>
     </div>

--- a/settings/index.html
+++ b/settings/index.html
@@ -83,11 +83,7 @@
             </div>
             <div class="bottombar">
                 <a class="alt-btn" href="/">Back</a>
-<<<<<<< Updated upstream
-                <a class="alt-btn" href="#" target="_blank">GitHub</a>
-=======
                 <a class="alt-btn" href="https://github.com/Ascript89/onliine/" target="_blank">GitHub</a>
->>>>>>> Stashed changes
             </div>
         </div>
     </div>


### PR DESCRIPTION
I fixed the GitHub button in the settings so it actually goes to this project's page instead of opening the same settings page in a new tab.